### PR TITLE
Update workflow to use ubuntu latest

### DIFF
--- a/.github/workflows/mra_validation.yml
+++ b/.github/workflows/mra_validation.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   validate:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Pinning a specific Ubuntu version will require more maintenance since GitHub will keep removing old versions in the future as they did with the 18.04